### PR TITLE
Bugfix/admin not prio

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Skojjt implementerar APN/DAK för redovisning till Göteborgs kommun:
 * Installera biblioteken. `pip install -r requirements.txt -t lib`
 * Konfigurera GAE `gcloud init` och följ instruktionerna.
 * Deploy kod `gcloud app deploy` från git mappen
+* Update indexes`gcloud datastore indexes create index.yaml`
 * Testa appen `gcloud app browse`
 
 ### Hur man testar/utvecklar på Mac:

--- a/data.py
+++ b/data.py
@@ -118,10 +118,10 @@ class ScoutGroup(ndb.Model):
 	
 	@staticmethod
 	def getgroupsforuser(user):
-		if user.groupaccess != None:
-			return [user.groupaccess.get()]
-		elif user.hasadminaccess:
+		if user.hasadminaccess:
 			return ScoutGroup.query().fetch(100)
+		elif user.groupaccess is not None:
+			return [user.groupaccess.get()]
 		else:
 			return []
 


### PR DESCRIPTION
Admins did get a very limited list on /start/ and /persons/,
if they also had an group-connection.

Now admin trumps the group-connection, and thus pages show all groups.