### PR TITLE
pylintrc alignment of naming styles

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -132,7 +132,8 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        missing-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -181,14 +182,14 @@ never-returning-functions=optparse.Values,sys.exit
 [BASIC]
 
 # Naming style matching correct argument names
-argument-naming-style=camelCase
+argument-naming-style=snake_case
 
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style
 #argument-rgx=
 
 # Naming style matching correct attribute names
-attr-naming-style=camelCase
+attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style
@@ -210,7 +211,7 @@ class-attribute-naming-style=any
 #class-attribute-rgx=
 
 # Naming style matching correct class names
-class-naming-style=camelCase
+class-naming-style=PascalCase
 
 # Regular expression matching correct class names. Overrides class-naming-style
 #class-rgx=
@@ -227,7 +228,7 @@ const-naming-style=UPPER_CASE
 docstring-min-length=-1
 
 # Naming style matching correct function names
-function-naming-style=camelCase
+function-naming-style=snake_case
 
 # Regular expression matching correct function names. Overrides function-
 # naming-style
@@ -252,14 +253,14 @@ inlinevar-naming-style=any
 #inlinevar-rgx=
 
 # Naming style matching correct method names
-method-naming-style=camelCase
+method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style
 #method-rgx=
 
 # Naming style matching correct module names
-module-naming-style=camelCase
+module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
 # style
@@ -278,7 +279,7 @@ no-docstring-rgx=^_
 property-classes=abc.abstractproperty
 
 # Naming style matching correct variable names
-variable-naming-style=camelCase
+variable-naming-style=snake_case
 
 # Regular expression matching correct variable names. Overrides variable-
 # naming-style


### PR DESCRIPTION
Updated naming-style to follow PEP8 since we are closer to that than to camelCase. Also suppressed missing-docstring.

Motivation:

PEP-8 recommends snake_case for everything but class-names which should be PascalCase.
Our current .pylintrc says snake_case for everything including class-names.

Checking our code by running `pylint *.py` gave the following scores (higher is better)

* 5.26 (current settings)
* 6.09 ignore "missing-docstring" (for now at least)
* 6.22 change argument-naming-style=PascalCase (better than snake_case, and as recommended)
* 6.25 change other *-naming-style=camelCase

Once this is accepted, one can start to improve stuff to get a higher pylint score.

