### PR TITLE
docker compose: add local port

### DIFF
--- a/docker-compose.yaml.template
+++ b/docker-compose.yaml.template
@@ -16,7 +16,7 @@ services:
         source: ./src
         target: /static/src
     ports:
-      - "80"
+      - "80:8080"
     environment:
       HOST_NAME: "localhost"
       MONGO_URI: "mongodb://%s:%s@mongo:27017/"


### PR DESCRIPTION
With this change running `docker compose up` should work out of the box
on more environments, automatically serving Skojjt on localhost:8080.