### PR TITLE
fix: right syntax for gitignore in gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -7,9 +7,9 @@
 #   $ gcloud topic gcloudignore
 #
 .gcloudignore
-!include:.gitignore
+#!include:.gitignore
 scripts/
-env/
+.git/
 .vscode/
 __pycache__/
 documentation/


### PR DESCRIPTION
Change.gcloudignore to propagate .gitignore files (including env/ and venv/